### PR TITLE
Escape strings in jupyter-config-data json

### DIFF
--- a/jupyterlab_launcher/handlers.py
+++ b/jupyterlab_launcher/handlers.py
@@ -79,6 +79,9 @@ class LabHandler(IPythonHandler):
 
         mathjax_config = self.settings.get('mathjax_config',
                                            'TeX-AMS_HTML-full,Safe')
+        
+        page_config = {key: json.dumps(value) for key, value in page_config.items()}
+
         config = dict(
             page_title=config.page_title,
             mathjax_url=self.mathjax_url,


### PR DESCRIPTION
On Windows, following the CONTRIBUTING.md instructions in jupyterlab fails when loading JupyterLab on a json parse exception.  The jupyter-config-data JSON includes Windows paths where slashes are not escaped.  Calling json.dumps on all page_config values fixes this.