### PR TITLE
Remove notebook dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+# http://travis-ci.org/#!/ipython/ipython
+language: python
+python:
+    - 3.6
+    - 2.7
+sudo: false
+install:
+    - pip install setuptools pip --upgrade
+    - pip install -e .
+script:
+    - cd 
+    - python -c "import jupyterlab_launcher"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-# http://travis-ci.org/#!/ipython/ipython
 language: python
 python:
     - 3.6

--- a/jupyterlab_launcher/app.py
+++ b/jupyterlab_launcher/app.py
@@ -3,8 +3,11 @@
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-from notebook.notebookapp import NotebookApp
-from traitlets import Unicode
+try:
+    from notebook.notebookapp import NotebookApp
+    from traitlets import Unicode
+except ImportError:
+    NotebookApp = object
 
 from .handlers import add_handlers, LabConfig
 

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,5 @@ setup_args = dict(
     ],
 )
 
-if 'setuptools' in sys.modules:
-    setup_args['install_requires'] = [
-        'notebook>=4.2.0',
-    ]
-
 if __name__ == '__main__':
     setup(**setup_args)


### PR DESCRIPTION
This will allow `pip install -U jupyterlab_launcher` to work without transitive deps.