### PR TITLE
We do not need to encode server provided urls

### DIFF
--- a/jupyterlab_launcher/index.html
+++ b/jupyterlab_launcher/index.html
@@ -20,9 +20,9 @@ Distributed under the terms of the Modified BSD License.
     {% for key, value in page_config.items() -%}
     "{{ key }}": "{{ value }}",
     {% endfor -%}
-    "baseUrl": "{{base_url | urlencode}}",
-    "wsUrl": "{{ws_url | urlencode}}",
-    "publicUrl": "{{public_url | urlencode}}"
+    "baseUrl": "{{ base_url }}",
+    "wsUrl": "{{ ws_url }}",
+    "publicUrl": "{{ public_url }}"
   }</script>
 
   {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="{{ base_url }}static/base/images/favicon.ico">{% endblock %}


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/2238 and mirrors what the Notebook [does](https://github.com/jupyter/notebook/blob/2ecda075e0d76435c1c78520be3a4e40397c1bf4/notebook/templates/page.html#L17).