### PR TITLE
Do not cache the static files

### DIFF
--- a/jupyterlab_launcher/handlers.py
+++ b/jupyterlab_launcher/handlers.py
@@ -176,7 +176,8 @@ def add_handlers(web_app, config):
     if config.assets_dir and not config.static_url:
         config.static_url = ujoin(base_url, default_static_path)
         handlers.append((config.static_url + "(.*)", FileFindHandler, {
-            'path': config.assets_dir
+            'path': config.assets_dir,
+            'no_cache_paths': ['/']  # don't cache anything
         }))
 
         package_file = os.path.join(config.assets_dir, 'package.json')


### PR DESCRIPTION
Otherwise we can't refresh the page after an auto-build and get the new version.