### PR TITLE
Remove trailing slash to fix theme relative urls

### DIFF
--- a/jupyterlab_launcher/handlers.py
+++ b/jupyterlab_launcher/handlers.py
@@ -34,6 +34,7 @@ class LabHandler(IPythonHandler):
         self.lab_config = lab_config
 
     @web.authenticated
+    @web.removeslash
     def get(self):
         config = self.lab_config
         settings_dir = config.settings_dir


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/2931.