### PR TITLE
Update settings handler to parse complex URL paths.

### DIFF
--- a/jupyterlab_launcher/handlers.py
+++ b/jupyterlab_launcher/handlers.py
@@ -188,11 +188,11 @@ def add_handlers(web_app, config):
         config.version = (config.version or data['jupyterlab']['version'] or
                           data['version'])
         config.name = config.name or data['jupyterlab']['name']
-    
-    # Handle the settings. 
+
+    # Handle the settings.
     if config.schemas_dir and not config.settings_url:
         config.settings_url = ujoin(base_url, default_settings_path)
-        settings_path = config.settings_url + '(?P<section_name>[\w.-]+)'
+        settings_path = config.settings_url + '(?P<section_name>.+)'
         handlers.append((settings_path, SettingsHandler, {
             'schemas_dir': config.schemas_dir,
             'settings_dir': config.user_settings_dir

--- a/jupyterlab_launcher/settings_handler.py
+++ b/jupyterlab_launcher/settings_handler.py
@@ -74,23 +74,6 @@ class SettingsHandler(APIHandler):
         self.set_status(204)
 
 
-def _path(root_dir, section_name, make_dirs = False):
-    """Parse the URL section name and find the local file system path."""
-
-    # Attempt to parse path, e.g. @jupyterlab/apputils-extension:themes.
-    try:
-        package_dir, plugin = section_name.split(":")
-        parent_dir = os.path.join(root_dir, package_dir)
-        path = os.path.join(parent_dir, plugin + ".json")
-    # This is deprecated and exists to support the older URL scheme.
-    except Exception as e:
-        path = os.path.join(root_dir, section_name + ".json")
-
-    if make_dirs and parent_dir and not os.path.exists(parent_dir):
-        os.makedirs(parent_dir)
-
-    return path
-
 def _get_schema(schemas_dir, section_name):
     """Retrieve and parse a JSON schema."""
 
@@ -109,3 +92,28 @@ def _get_schema(schemas_dir, section_name):
             raise web.HTTPError(500, message)
 
     return schema
+
+
+def _path(root_dir, section_name, make_dirs = False):
+    """Parse the URL section name and find the local file system path."""
+
+    parent_dir = ""
+
+    # Attempt to parse path, e.g. @jupyterlab/apputils-extension:themes.
+    try:
+        package_dir, plugin = section_name.split(":")
+        parent_dir = os.path.join(root_dir, package_dir)
+        path = os.path.join(parent_dir, plugin + ".json")
+    # This is deprecated and exists to support the older URL scheme.
+    except:
+        path = os.path.join(root_dir, section_name + ".json")
+
+    if make_dirs and parent_dir and not os.path.exists(parent_dir):
+        try:
+            os.makedirs(parent_dir)
+        except Exception as e:
+            name = section_name
+            message = "Failed writing settings ({}): {}".format(name, str(e))
+            raise web.HTTPError(500, message)
+
+    return path

--- a/jupyterlab_launcher/settings_handler.py
+++ b/jupyterlab_launcher/settings_handler.py
@@ -5,7 +5,6 @@
 import json
 import os
 from tornado import web
-import pdb
 
 from notebook.base.handlers import APIHandler, json_errors
 

--- a/jupyterlab_launcher/settings_handler.py
+++ b/jupyterlab_launcher/settings_handler.py
@@ -5,6 +5,7 @@
 import json
 import os
 from tornado import web
+import pdb
 
 from notebook.base.handlers import APIHandler, json_errors
 
@@ -24,22 +25,12 @@ class SettingsHandler(APIHandler):
     @json_errors
     @web.authenticated
     def get(self, section_name):
-        self.set_header('Content-Type', "application/json")
-        path = os.path.join(self.schemas_dir, section_name + ".json")
+        self.set_header("Content-Type", "application/json")
 
-        if not os.path.exists(path):
-            raise web.HTTPError(404, "Schema not found: %r" % section_name)
-        with open(path) as fid:
-            # Attempt to load the schema file.
-            try:
-                schema = json.load(fid)
-            except Exception as e:
-                name = section_name
-                message = "Failed parsing schema ({}): {}".format(name, str(e))
-                raise web.HTTPError(500, message)
-
-        path = os.path.join(self.settings_dir, section_name + '.json')
+        schema = _get_schema(self.schemas_dir, section_name)
+        path = _path(self.settings_dir, section_name)
         settings = dict()
+
         if os.path.exists(path):
             with open(path) as fid:
                 # Attempt to load the settings file.
@@ -66,30 +57,55 @@ class SettingsHandler(APIHandler):
         if not self.settings_dir:
             raise web.HTTPError(404, "No current settings directory")
 
-        path = os.path.join(self.schemas_dir, section_name + '.json')
-
-        if not os.path.exists(path):
-            raise web.HTTPError(404, "Schema not found for: %r" % section_name)
-
-        data = self.get_json_body()  # Will raise 400 if content is not valid JSON
+        # Will raise 400 if content is not valid JSON.
+        data = self.get_json_body()
 
         # Validate the data against the schema.
         if Validator is not None:
-            with open(path) as fid:
-                schema = json.load(fid)
-            validator = Validator(schema)
+            validator = Validator(_get_schema(self.schemas_dir, section_name))
             try:
                 validator.validate(data)
             except ValidationError as e:
                 raise web.HTTPError(400, str(e))
 
-        # Create the settings dir as needed.
-        if not os.path.exists(self.settings_dir):
-            os.makedirs(self.settings_dir)
-
-        path = os.path.join(self.settings_dir, section_name + '.json')
-
-        with open(path, 'w') as fid:
+        with open(_path(self.settings_dir, section_name, True), "w") as fid:
             json.dump(data, fid)
 
         self.set_status(204)
+
+
+def _path(root_dir, section_name, make_dirs = False):
+    """Parse the URL section name and find the local file system path."""
+
+    # Attempt to parse path, e.g. @jupyterlab/apputils-extension:themes.
+    try:
+        package_dir, plugin = section_name.split(":")
+        parent_dir = os.path.join(root_dir, package_dir)
+        path = os.path.join(parent_dir, plugin + ".json")
+    # This is deprecated and exists to support the older URL scheme.
+    except Exception as e:
+        path = os.path.join(root_dir, section_name + ".json")
+
+    if make_dirs and parent_dir and not os.path.exists(parent_dir):
+        os.makedirs(parent_dir)
+
+    return path
+
+def _get_schema(schemas_dir, section_name):
+    """Retrieve and parse a JSON schema."""
+
+    path = _path(schemas_dir, section_name)
+
+    if not os.path.exists(path):
+        raise web.HTTPError(404, "Schema not found: %r" % path)
+
+    with open(path) as fid:
+        # Attempt to load the schema file.
+        try:
+            schema = json.load(fid)
+        except Exception as e:
+            name = section_name
+            message = "Failed parsing schema ({}): {}".format(name, str(e))
+            raise web.HTTPError(500, message)
+
+    return schema

--- a/jupyterlab_launcher/tests/schemas/@jupyterlab/apputils-extension/themes.json
+++ b/jupyterlab_launcher/tests/schemas/@jupyterlab/apputils-extension/themes.json
@@ -1,0 +1,10 @@
+{
+  "title": "Theme",
+  "description": "Theme manager settings.",
+  "properties": {
+    "theme": {
+      "type": "string", "title": "Selected Theme", "default": "JupyterLab Light"
+    }
+  },
+  "type": "object"
+}

--- a/jupyterlab_launcher/tests/test_settings_api.py
+++ b/jupyterlab_launcher/tests/test_settings_api.py
@@ -23,7 +23,14 @@ class SettingsAPITest(LabTestBase):
     def setUp(self):
         self.settings_api = SettingsAPI(self.request)
 
-    def test_get(self):
+    def test_new_get(self):
+        id = '@jupyterlab/apputils-extension:themes'
+        data = self.settings_api.get(id).json()
+        assert data['id'] == id
+        assert len(data['schema'])
+        assert 'data' in data
+
+    def test_old_get(self):
         id = 'jupyter.extensions.shortcuts'
         data = self.settings_api.get(id).json()
         assert data['id'] == id


### PR DESCRIPTION
Supports making API requests to the settings handler in with the new ID schema from https://github.com/jupyterlab/jupyterlab/pull/2936

(This is a backward compatible API change.)