### PR TITLE
Remove MathJax and Streamline Handler config

### DIFF
--- a/jupyterlab_launcher/handlers.py
+++ b/jupyterlab_launcher/handlers.py
@@ -10,21 +10,19 @@ from tornado import web
 from notebook.base.handlers import IPythonHandler, FileFindHandler
 from jinja2 import FileSystemLoader
 from notebook.utils import url_path_join as ujoin
-from traitlets import HasTraits, Unicode, Bool, List
+from traitlets import HasTraits, Bool, Unicode
 
 from .settings_handler import SettingsHandler
 
-#-----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
 # Module globals
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
-HERE = os.path.dirname(__file__)
-FILE_LOADER = FileSystemLoader(HERE)
-
-# The default paths for the application.
-default_static_path = r'lab/static/'
-default_settings_path = r'lab/api/settings/'
-default_themes_path = r'/lab/api/themes/'
+# The default urls for the application.
+default_public_url = '/lab/static/'
+default_settings_url = '/lab/api/settings/'
+default_themes_url = '/lab/api/themes/'
 
 
 class LabHandler(IPythonHandler):
@@ -32,57 +30,32 @@ class LabHandler(IPythonHandler):
 
     def initialize(self, lab_config):
         self.lab_config = lab_config
+        self.file_loader = FileSystemLoader(lab_config.templates_dir)
 
     @web.authenticated
     @web.removeslash
     def get(self):
         config = self.lab_config
-        settings_dir = config.settings_dir
-        page_config_file = os.path.join(settings_dir, 'page_config.json')
-        assets_dir = config.assets_dir
-
-        js_files = set(config.static_js_urls)
-        css_files = set(config.static_css_urls)
-
-        if config.assets_dir:
-            for entry in ['main']:
-                css_file = entry + '.css'
-                if os.path.isfile(os.path.join(assets_dir, css_file)):
-                    css_files.add(ujoin(config.static_url, css_file))
-                bundle_file = entry + '.bundle.js'
-                if os.path.isfile(os.path.join(assets_dir, bundle_file)):
-                    js_files.add(ujoin(config.static_url, bundle_file))
-
-        if not js_files:
-            msg = '%s assets not found in "%s"'
-            msg = msg % (config.name, config.assets_dir)
-            self.log.error(config.error_message or msg)
-            self.write(self.render_template('error.html',
-                       status_code=500,
-                       status_message='%s Error' % config.name,
-                       page_title='%s Error' % config.name,
-                       message=msg))
-            return
+        settings_dir = config.app_settings_dir
 
         # Handle page config data.
-        page_config = dict()
-        page_config.update(self.settings.get('page_config_data', {}))
+        page_config = self.settings.getdefault('page_config_data', {})
         terminals = self.settings.get('terminals_available', False)
+        server_root = self.settings.get('server_root_dir', '')
         page_config.setdefault('terminalsAvailable', terminals)
         page_config.setdefault('ignorePlugins', [])
-        page_config.setdefault('appName', config.name)
-        page_config.setdefault('appVersion', config.version)
-        page_config.setdefault('appNamespace', config.namespace)
-        page_config.setdefault('devMode', config.dev_mode)
-        page_config.setdefault('settingsPath', config.settings_url)
-        page_config.setdefault('themePath', config.themes_url)
-        page_config.setdefault(
-            'settingsDir', config.settings_dir.replace(os.sep, '/')
-        )
-        page_config.setdefault(
-            'assetsDir', config.assets_dir.replace(os.sep, '/')
-        )
+        page_config.setdefault('serverRoot', server_root)
 
+        mathjax_config = self.settings.get('mathjax_config',
+                                           'TeX-AMS_HTML-full,Safe')
+        page_config.setdefault('mathjaxConfig', mathjax_config)
+        page_config.setdefault('mathjaxUrl', self.mathjax_url)
+
+        for name in config.trait_names():
+            page_config[name] = getattr(config, name)
+
+        # Load the current page config file if available.
+        page_config_file = os.path.join(settings_dir, 'page_config.json')
         if os.path.exists(page_config_file):
             with open(page_config_file) as fid:
                 try:
@@ -90,82 +63,74 @@ class LabHandler(IPythonHandler):
                 except Exception as e:
                     print(e)
 
-        mathjax_config = self.settings.get('mathjax_config',
-                                           'TeX-AMS_HTML-full,Safe')
+        # Wrap the page config in a dictionary to give it a namespace.
+        config = dict(page_config=page_config)
 
-        config = dict(
-            page_title=config.page_title,
-            mathjax_url=self.mathjax_url,
-            mathjax_config=mathjax_config,
-            css_files=css_files,
-            js_files=js_files,
-            page_config=page_config,
-            public_url=config.static_url
-        )
+        # Handle error when the assets are not available locally.
+        local_index = os.path.join(config.static_dir, 'index.html')
+        if config.static_dir and not os.path.exists(local_index):
+            self.write(self.render_template('error.html', **config))
+            return
+
+        # Write the template with the config.
         self.write(self.render_template('index.html', **config))
 
     def get_template(self, name):
-        return FILE_LOADER.load(self.settings['jinja2_env'], name)
+        return self.file_loader.load(self.settings['jinja2_env'], name)
 
 
 class LabConfig(HasTraits):
     """The lab application configuration object.
     """
-    settings_dir = Unicode('',
+    page_url = Unicode('/lab',
+        help='The url path for the application')
+
+    app_settings_dir = Unicode('',
         help='The application settings directory')
 
-    assets_dir = Unicode('',
-        help='The location of the static assets directory')
+    templates_dir = Unicode('',
+        help='The templates directory for the application')
 
-    name = Unicode('',
-        help='The name of the application')
+    static_dir = Unicode('',
+        help=('The optional location of the local static files.  '
+              'If given, a handler will be added to server the files.'))
 
-    version = Unicode('',
-        help='The version of the application')
+    public_url = Unicode(default_public_url,
+        help=('The url public path for the application static files.  '
+              'This can be a CDN if desired'))
 
-    namespace = Unicode('',
-        help='The namespace for the application')
-
-    error_message = Unicode('',
-        help='The error message to show when assets are not detected')
-
-    page_title = Unicode('JupyterLab',
-        help='The page title for the application')
-
-    page_url = Unicode('/lab',
-        help='The url for the application')
-
-    static_url = Unicode('',
-        help='The optional override static url for the application')
-
-    static_js_urls = List(Unicode(),
-        help='The optional list of static JavaScript urls to serve')
-
-    static_css_urls = List(Unicode(),
-        help='The optional list of static CSS urls to serve')
-
-    dev_mode = Bool(False,
-        help='Whether the application is in dev mode')
-
-    settings_url = Unicode('',
-        help='The optional override url of the settings handler')
-
-    schemas_dir = Unicode('',
-        help='The location of the settings schemas directory')
+    settings_url = Unicode(default_settings_url,
+        help='The url path of the settings handler')
 
     user_settings_dir = Unicode('',
-        help='The location of the user settings directory')
+        help='The optional location of the user settings directory')
 
-    themes_url = Unicode('',
-        help='The optional theme override url')
+    schemas_dir = Unicode('',
+        help='The optional location of the settings schemas directory.  '
+              'If given, a handler will be added for settings')
+
+    themes_url = Unicode(default_themes_url,
+        help='The theme path')
 
     themes_dir = Unicode('',
-        help='The location of the themes directory')
+        help=('The optional location of the themes directory.  '
+              'If given, a handler will be added for themes'))
+
+    cache_files = Bool(True,
+        help=('Whether to cache files on the server. This should be '
+              '`True` unless in development mode'))
 
 
 def add_handlers(web_app, config):
     """Add the appropriate handlers to the web app.
     """
+    # Normalize directories.
+    for name in config.trait_names():
+        if not name.endswith('_dir'):
+            continue
+        value = getattr(config, name)
+        setattr(config, name, value.replace(os.sep, '/'))
+
     # Set up the main page handler.
     base_url = web_app.settings['base_url']
     handlers = [
@@ -174,28 +139,20 @@ def add_handlers(web_app, config):
         })
     ]
 
-    # Handle the static assets.
-    if config.assets_dir and not config.static_url:
-        config.static_url = ujoin(base_url, default_static_path)
+    # Cache all or none of the files depending on the `cache_files` setting.
+    no_cache_paths = ['/'] if config.cache_files else []
+
+    # Handle local static assets.
+    if config.assets_dir:
+        config.public_url = ujoin(base_url, default_public_url)
         handlers.append((config.static_url + "(.*)", FileFindHandler, {
             'path': config.assets_dir,
-            'no_cache_paths': ['/']  # don't cache anything
+            'no_cache_paths': no_cache_paths
         }))
 
-        package_file = os.path.join(config.assets_dir, 'package.json')
-        if os.path.exists(package_file):
-            with open(package_file) as fid:
-                data = json.load(fid)
-
-            config.version = (
-                config.version or data['jupyterlab']['version'] or
-                data['version']
-            )
-            config.name = config.name or data['jupyterlab']['name']
-
-    # Handle the settings.
-    if config.schemas_dir and not config.settings_url:
-        config.settings_url = ujoin(base_url, default_settings_path)
+    # Handle local settings.
+    if config.schemas_dir:
+        config.settings_url = ujoin(base_url, default_settings_url)
         settings_path = config.settings_url + '(?P<section_name>.+)'
         handlers.append((settings_path, SettingsHandler, {
             'app_settings_dir': config.settings_dir,
@@ -203,14 +160,12 @@ def add_handlers(web_app, config):
             'settings_dir': config.user_settings_dir
         }))
 
-    # Handle the themes.
-    if config.themes_dir and not config.themes_url:
-        config.themes_url = ujoin(base_url, default_themes_path)
+    # Handle local themes.
+    if config.themes_dir:
+        config.themes_url = ujoin(base_url, default_themes_url)
         handlers.append((ujoin(config.themes_url, "(.*)"), FileFindHandler, {
             'path': config.themes_dir,
-            'no_cache_paths': ['/']  # don't cache anything
+            'no_cache_paths': no_cache_paths
         }))
-
-    config.name = config.name or 'Application'
 
     web_app.add_handlers(".*$", handlers)

--- a/jupyterlab_launcher/handlers.py
+++ b/jupyterlab_launcher/handlers.py
@@ -90,12 +90,11 @@ class LabHandler(IPythonHandler):
         self.write(self.render_template('index.html', page_config=page_config))
 
     def get_template(self, name):
-        name = 'foo'
         return self.file_loader.load(self.settings['jinja2_env'], name)
 
     def render_template(self, name, **ns):
         try:
-            IPythonHandler.render_template(self, name, **ns)
+            return IPythonHandler.render_template(self, name, **ns)
         except TemplateError:
             return DEFAULT_TEMPLATE.generate(
                 name=name, path=self.lab_config.templates_dir

--- a/jupyterlab_launcher/handlers.py
+++ b/jupyterlab_launcher/handlers.py
@@ -52,7 +52,7 @@ class LabHandler(IPythonHandler):
         page_config.setdefault('mathjaxUrl', self.mathjax_url)
 
         for name in config.trait_names():
-            page_config[name] = getattr(config, name)
+            page_config[_camelCase[name]] = getattr(config, name)
 
         # Load the current page config file if available.
         page_config_file = os.path.join(settings_dir, 'page_config.json')
@@ -82,6 +82,15 @@ class LabHandler(IPythonHandler):
 class LabConfig(HasTraits):
     """The lab application configuration object.
     """
+    app_name = Unicode('',
+        help='The name of the application')
+
+    app_version = Unicode('',
+        help='The version of the application')
+
+    app_namespace = Unicode('',
+        help='The namespace of the application')
+
     page_url = Unicode('/lab',
         help='The url path for the application')
 
@@ -110,7 +119,7 @@ class LabConfig(HasTraits):
               'If given, a handler will be added for settings')
 
     themes_url = Unicode(default_themes_url,
-        help='The theme path')
+        help='The theme url')
 
     themes_dir = Unicode('',
         help=('The optional location of the themes directory.  '
@@ -169,3 +178,11 @@ def add_handlers(web_app, config):
         }))
 
     web_app.add_handlers(".*$", handlers)
+
+
+def _camelCase(base):
+    """Convert a string to camelCase.
+    https://stackoverflow.com/a/20744956
+    """
+    output = ''.join(x for x in base.title() if x.isalpha())
+    return output[0].lower() + output[1:]

--- a/jupyterlab_launcher/index.html
+++ b/jupyterlab_launcher/index.html
@@ -31,10 +31,6 @@ Distributed under the terms of the Modified BSD License.
   <script src="{{ js_file }}" type="text/javascript" charset="utf-8"></script>
   {% endfor %}
 
-  {% if mathjax_url %}
-  <script type="text/javascript" src="{{mathjax_url}}?config={{mathjax_config}}&amp;delayStartupUntil=configured" charset="utf-8"></script>
-  {% endif %}
-
   {% block meta %}
   {% endblock %}
 


### PR DESCRIPTION
MathJax handling will be moving to a separate plugin in https://github.com/jupyterlab/jupyterlab/pull/3135.
Html files are now provided by the JupyterLab build: we only add tornado handlers and some page config variables now.