### PR TITLE
Allow an admin to override extension schema defaults.

### DIFF
--- a/jupyterlab_launcher/handlers.py
+++ b/jupyterlab_launcher/handlers.py
@@ -198,6 +198,7 @@ def add_handlers(web_app, config):
         config.settings_url = ujoin(base_url, default_settings_path)
         settings_path = config.settings_url + '(?P<section_name>.+)'
         handlers.append((settings_path, SettingsHandler, {
+            'app_settings_dir': config.settings_dir,
             'schemas_dir': config.schemas_dir,
             'settings_dir': config.user_settings_dir
         }))


### PR DESCRIPTION
This PR allows an administrator to create a file called `overrides.json` in the JupyterLab application settings directory (which can be found by running `jupyter lab paths`. Each key in that file should be the name of an extension (*e.g.* ` "@jupyterlab/apputils-extension:themes"`) and the value of that key should be an object with individual settings that the administrator wants to override. For example, an `overrides.json` file might look like this:

```json
{
  "@jupyterlab/apputils-extension:themes": {
    "theme": "JupyterLab Dark"
  }
}
```

Using this functionality, any default value set by an extension author can be overridden.