### PR TITLE
Add a simple /tree handler.

### DIFF
--- a/jupyterlab_launcher/handlers.py
+++ b/jupyterlab_launcher/handlers.py
@@ -155,8 +155,6 @@ class LabConfig(HasTraits):
         help=('Whether to cache files on the server. This should be '
               '`True` unless in development mode'))
 
-class TreeHandler(LabHandler):
-    pass
 
 def add_handlers(web_app, config):
     """Add the appropriate handlers to the web app.
@@ -174,7 +172,7 @@ def add_handlers(web_app, config):
         (ujoin(base_url, config.page_url, r'/?'), LabHandler, {
             'lab_config': config
         }),
-        (ujoin(base_url, config.tree_url, r'/?'), TreeHandler, {
+        (ujoin(base_url, config.tree_url, r'/?.*'), LabHandler, {
             'lab_config': config
         })
     ]

--- a/jupyterlab_launcher/handlers.py
+++ b/jupyterlab_launcher/handlers.py
@@ -23,6 +23,7 @@ from .themes_handler import ThemesHandler
 default_public_url = '/lab/static/'
 default_settings_url = '/lab/api/settings/'
 default_themes_url = '/lab/api/themes/'
+default_tree_url = '/lab/tree/'
 
 
 DEFAULT_TEMPLATE = template.Template("""
@@ -147,10 +148,15 @@ class LabConfig(HasTraits):
         help=('The optional location of the themes directory.  '
               'If given, a handler will be added for themes'))
 
+    tree_url = Unicode(default_tree_url,
+        help='The url path of the tree handler')
+
     cache_files = Bool(True,
         help=('Whether to cache files on the server. This should be '
               '`True` unless in development mode'))
 
+class TreeHandler(LabHandler):
+    pass
 
 def add_handlers(web_app, config):
     """Add the appropriate handlers to the web app.
@@ -166,6 +172,9 @@ def add_handlers(web_app, config):
     base_url = web_app.settings['base_url']
     handlers = [
         (ujoin(base_url, config.page_url, r'/?'), LabHandler, {
+            'lab_config': config
+        }),
+        (ujoin(base_url, config.tree_url, r'/?'), TreeHandler, {
             'lab_config': config
         })
     ]

--- a/jupyterlab_launcher/handlers.py
+++ b/jupyterlab_launcher/handlers.py
@@ -155,6 +155,13 @@ class LabConfig(HasTraits):
         help=('Whether to cache files on the server. This should be '
               '`True` unless in development mode'))
 
+class NotFoundHandler(LabHandler):
+    def render_template(self, name, **ns):
+        if 'page_config' in ns:
+            ns['page_config'] = ns['page_config'].copy()
+            ns['page_config']['notFoundUrl'] = self.request.path
+        return LabHandler.render_template(self, name, **ns)
+
 
 def add_handlers(web_app, config):
     """Add the appropriate handlers to the web app.
@@ -206,6 +213,11 @@ def add_handlers(web_app, config):
             'path': config.themes_dir,
             'no_cache_paths': no_cache_paths
         }))
+
+    # Let the lab handler act as the fallthrough option instead of a 404.
+    handlers.append((ujoin(base_url, config.page_url, r'/?.*'), NotFoundHandler, {
+        'lab_config': config
+    }))
 
     web_app.add_handlers(".*$", handlers)
 


### PR DESCRIPTION
This PR provides a handler for all URLs that begin with the `tree_url` prefix. The default value for `tree_url` is `/lab/tree/`. The handler returns exactly what the `LabHandler` returns for HTTP `get` requests because it is simply an instance of the `LabHandler` that matches a permissive regular expression.

The JupyterLab front-end will need to read the URL and decide how to manifest the URL in the application state (*e.g.*, open a folder or a notebook, *etc.*): https://github.com/jupyterlab/jupyterlab/pull/3396