### PR TITLE
Update /lab/api/workspaces REST endpoints.

### DIFF
--- a/jupyterlab_launcher/app.py
+++ b/jupyterlab_launcher/app.py
@@ -6,15 +6,13 @@
 from notebook.notebookapp import NotebookApp
 from traitlets import Unicode
 
-from .handlers import add_handlers, LabConfig
+from .handlers import add_handlers
 
 
 class LabLauncherApp(NotebookApp):
 
     default_url = Unicode('/lab',
                           help='The default URL to redirect to from `/`')
-
-    lab_config = LabConfig()
 
     def start(self):
         add_handlers(self.web_app, self.lab_config)

--- a/jupyterlab_launcher/app.py
+++ b/jupyterlab_launcher/app.py
@@ -6,13 +6,15 @@
 from notebook.notebookapp import NotebookApp
 from traitlets import Unicode
 
-from .handlers import add_handlers
+from .handlers import add_handlers, LabConfig
 
 
 class LabLauncherApp(NotebookApp):
 
     default_url = Unicode('/lab',
                           help='The default URL to redirect to from `/`')
+
+    lab_config = LabConfig()
 
     def start(self):
         add_handlers(self.web_app, self.lab_config)

--- a/jupyterlab_launcher/handlers.py
+++ b/jupyterlab_launcher/handlers.py
@@ -222,8 +222,17 @@ def add_handlers(web_app, config):
 
         # Handle API requests for workspaces.
         config.workspaces_api_url = ujoin(base_url, default_workspaces_api_url)
-        workspaces_api_path = config.workspaces_api_url + '(?P<space_name>.+)'
+
+        # Handle requests for the list of workspaces. Make slash optional.
+        workspaces_api_path = config.workspaces_api_url + '?'
         handlers.append((workspaces_api_path, WorkspacesHandler, {
+            'workspaces_url': config.workspaces_url,
+            'path': config.workspaces_dir
+        }))
+
+        # Handle requests for an individually named workspace.
+        workspace_api_path = config.workspaces_api_url + '(?P<space_name>.+)'
+        handlers.append((workspace_api_path, WorkspacesHandler, {
             'workspaces_url': config.workspaces_url,
             'path': config.workspaces_dir
         }))

--- a/jupyterlab_launcher/process_app.py
+++ b/jupyterlab_launcher/process_app.py
@@ -9,6 +9,7 @@ from notebook.notebookapp import NotebookApp
 from tornado.ioloop import IOLoop
 from traitlets import Bool
 
+from .handlers import add_handlers, LabConfig
 from .process import Process
 
 
@@ -16,6 +17,8 @@ class ProcessApp(NotebookApp):
     """A notebook app that runs a separate process and exits on completion."""
 
     open_browser = Bool(False)
+
+    lab_config = LabConfig()
 
     def get_command(self):
         """Get the command and kwargs to run with `Process`.
@@ -26,6 +29,7 @@ class ProcessApp(NotebookApp):
     def start(self):
         """Start the application.
         """
+        add_handlers(self.web_app, self.lab_config)
         IOLoop.current().add_callback(self._run_command)
         NotebookApp.start(self)
 

--- a/jupyterlab_launcher/settings_handler.py
+++ b/jupyterlab_launcher/settings_handler.py
@@ -32,8 +32,6 @@ class SettingsHandler(APIHandler):
     @json_errors
     @web.authenticated
     def get(self, section_name):
-        self.set_header('Content-Type', 'application/json')
-
         schema = _get_schema(self.schemas_dir, section_name, self.overrides)
         path = _path(self.settings_dir, section_name, _file_extension)
         raw = '{}'

--- a/jupyterlab_launcher/tests/test_settings_api.py
+++ b/jupyterlab_launcher/tests/test_settings_api.py
@@ -26,6 +26,7 @@ class SettingsAPITest(LabTestBase):
     def test_get(self):
         id = '@jupyterlab/apputils-extension:themes'
         data = self.settings_api.get(id).json()
+
         assert data['id'] == id
         assert len(data['schema'])
         assert 'raw' in data
@@ -36,8 +37,8 @@ class SettingsAPITest(LabTestBase):
 
     def test_patch(self):
         id = '@jupyterlab/shortcuts-extension:plugin'
-        resp = self.settings_api.put(id, dict())
-        assert resp.status_code == 204
+
+        assert self.settings_api.put(id, dict()).status_code == 204
 
     def test_patch_wrong_id(self):
         with assert_http_error(404):
@@ -45,6 +46,6 @@ class SettingsAPITest(LabTestBase):
 
     def test_patch_bad_data(self):
         id = '@jupyterlab/codemirror-extension:commands'
-        data = dict(keyMap=10)
+
         with assert_http_error(400):
-            self.settings_api.put(id, data)
+            self.settings_api.put(id, dict(keyMap=10))

--- a/jupyterlab_launcher/tests/test_settings_api.py
+++ b/jupyterlab_launcher/tests/test_settings_api.py
@@ -1,5 +1,7 @@
 """Test the kernels service API."""
 import json
+import os
+import shutil
 
 from jupyterlab_launcher.tests.utils import LabTestBase, APITester
 from notebook.tests.launchnotebook import assert_http_error
@@ -21,6 +23,13 @@ class SettingsAPITest(LabTestBase):
     """Test the settings web service API"""
 
     def setUp(self):
+        src = os.path.join(
+            os.path.abspath(os.path.dirname(__file__)),
+            'schemas',
+            '@jupyterlab')
+        dst = os.path.join(self.lab_config.schemas_dir, '@jupyterlab')
+        if not os.path.exists(dst):
+            shutil.copytree(src, dst)
         self.settings_api = SettingsAPI(self.request)
 
     def test_get(self):

--- a/jupyterlab_launcher/tests/test_workspaces_api.py
+++ b/jupyterlab_launcher/tests/test_workspaces_api.py
@@ -9,6 +9,9 @@ class WorkspacesAPI(APITester):
 
     url = 'lab/api/workspaces'
 
+    def delete(self, section_name):
+        return self._req('DELETE', section_name)
+
     def get(self, section_name):
         return self._req('GET', section_name)
 
@@ -22,13 +25,22 @@ class WorkspacesAPITest(LabTestBase):
     def setUp(self):
         self.workspaces_api = WorkspacesAPI(self.request)
 
+    def test_delete(self):
+        orig = 'foo'
+        copy = 'bar'
+        data = self.workspaces_api.get(orig).json()
+        data['metadata']['id'] = copy
+
+        assert self.workspaces_api.put(copy, data).status_code == 204
+        assert self.workspaces_api.delete(copy).status_code == 204
+
     def test_get(self):
         id = 'foo'
-        data = self.workspaces_api.get(id).json()
-        assert data['metadata']['id'] == id
+
+        assert self.workspaces_api.get(id).json()['metadata']['id'] == id
 
     def test_put(self):
         id = 'foo'
         data = self.workspaces_api.get(id).json()
-        resp = self.workspaces_api.put(id, data)
-        assert resp.status_code == 204
+
+        assert self.workspaces_api.put(id, data).status_code == 204

--- a/jupyterlab_launcher/tests/test_workspaces_api.py
+++ b/jupyterlab_launcher/tests/test_workspaces_api.py
@@ -12,7 +12,7 @@ class WorkspacesAPI(APITester):
     def delete(self, section_name):
         return self._req('DELETE', section_name)
 
-    def get(self, section_name):
+    def get(self, section_name=''):
         return self._req('GET', section_name)
 
     def put(self, section_name, body):
@@ -27,7 +27,7 @@ class WorkspacesAPITest(LabTestBase):
 
     def test_delete(self):
         orig = 'foo'
-        copy = 'bar'
+        copy = 'baz'
         data = self.workspaces_api.get(orig).json()
         data['metadata']['id'] = copy
 
@@ -38,6 +38,11 @@ class WorkspacesAPITest(LabTestBase):
         id = 'foo'
 
         assert self.workspaces_api.get(id).json()['metadata']['id'] == id
+
+    def test_listing(self):
+        listing = set(['foo', 'bar'])
+
+        assert set(self.workspaces_api.get().json()['workspaces']) == listing
 
     def test_put(self):
         id = 'foo'

--- a/jupyterlab_launcher/tests/test_workspaces_api.py
+++ b/jupyterlab_launcher/tests/test_workspaces_api.py
@@ -1,5 +1,7 @@
 """Test the kernels service API."""
 import json
+import os
+import shutil
 
 from jupyterlab_launcher.tests.utils import LabTestBase, APITester
 
@@ -23,6 +25,14 @@ class WorkspacesAPITest(LabTestBase):
     """Test the workspaces web service API"""
 
     def setUp(self):
+        data = os.path.join(
+            os.path.abspath(os.path.dirname(__file__)),
+            'workspaces')
+        for item in os.listdir(data):
+            src = os.path.join(data, item)
+            dst = os.path.join(self.lab_config.workspaces_dir, item)
+            if not os.path.exists(dst):
+                shutil.copy(src, self.lab_config.workspaces_dir)
         self.workspaces_api = WorkspacesAPI(self.request)
 
     def test_delete(self):

--- a/jupyterlab_launcher/tests/workspaces/bar.jupyterlab-workspace
+++ b/jupyterlab_launcher/tests/workspaces/bar.jupyterlab-workspace
@@ -1,1 +1,1 @@
-{"metadata": {"id": "bar"}, "data": {}}
+{"data": {}, "metadata": {"id": "bar"}}

--- a/jupyterlab_launcher/tests/workspaces/bar.jupyterlab-workspace
+++ b/jupyterlab_launcher/tests/workspaces/bar.jupyterlab-workspace
@@ -1,0 +1,1 @@
+{"metadata": {"id": "bar"}, "data": {}}

--- a/jupyterlab_launcher/tests/workspaces/foo.jupyterlab-workspace
+++ b/jupyterlab_launcher/tests/workspaces/foo.jupyterlab-workspace
@@ -1,1 +1,1 @@
-{"metadata": {"id": "foo"}, "data": {}}
+{"data": {}, "metadata": {"id": "foo"}}

--- a/jupyterlab_launcher/workspaces_handler.py
+++ b/jupyterlab_launcher/workspaces_handler.py
@@ -21,22 +21,21 @@ class WorkspacesHandler(APIHandler):
         if not self.workspaces_dir:
             raise web.HTTPError(500, 'No current workspaces directory set')
 
+        return self.workspaces_dir
+
     @json_errors
     @web.authenticated
     def delete(self, space_name):
-        self.set_header('Content-Type', 'application/json')
-        self.ensure_directory()
-        directory = self.workspaces_dir
+        directory = self.ensure_directory()
 
         if not space_name:
             raise web.HTTPError(400, 'Workspace name is required for DELETE')
 
         workspace_path = os.path.join(directory, space_name + _file_extension)
         if not os.path.exists(workspace_path):
-            raise web.HTTPError(404, 'Workspace not found: %r' % space_name)
+            raise web.HTTPError(404, 'Workspace %r not found' % space_name)
 
-        # Attempt to delete the workspace file.
-        try:
+        try:  # to delete the workspace file.
             os.remove(workspace_path)
         except Exception as e:
             raise web.HTTPError(500, str(e))
@@ -46,9 +45,7 @@ class WorkspacesHandler(APIHandler):
     @json_errors
     @web.authenticated
     def get(self, space_name=''):
-        self.set_header('Content-Type', 'application/json')
-        self.ensure_directory()
-        directory = self.workspaces_dir
+        directory = self.ensure_directory()
 
         if not space_name:
             raise web.HTTPError(404, 'Workspaces list not yet implemented')
@@ -56,21 +53,19 @@ class WorkspacesHandler(APIHandler):
         workspace_path = os.path.join(directory, space_name + _file_extension)
         if os.path.exists(workspace_path):
             with open(workspace_path) as fid:
-                # Attempt to load and parse the workspace file.
-                try:
+                try:  # to load and parse the workspace file.
                     workspace = json.load(fid)
                 except Exception as e:
                     raise web.HTTPError(500, str(e))
         else:
-            raise web.HTTPError(404, 'Workspace not found: %r' % space_name)
+            raise web.HTTPError(404, 'Workspace %r not found' % space_name)
 
         self.finish(json.dumps(workspace))
 
     @json_errors
     @web.authenticated
     def put(self, space_name):
-        self.ensure_directory()
-        directory = self.workspaces_dir
+        directory = self.ensure_directory()
 
         if not os.path.exists(directory):
             try:

--- a/jupyterlab_launcher/workspaces_handler.py
+++ b/jupyterlab_launcher/workspaces_handler.py
@@ -51,9 +51,10 @@ class WorkspacesHandler(APIHandler):
                 return self.finish(json.dumps(dict(workspaces=[])))
 
             try:  # to read the contents of the workspaces directory.
-                items = map(lambda x: x.name, os.scandir(directory))
-                items = filter(lambda x: x.endswith(_file_extension), items)
-                items = sorted(map(lambda x: x[:-len(_file_extension)], items))
+                items = [item[:-len(_file_extension)]
+                         for item in os.listdir(directory)
+                         if item.endswith(_file_extension)]
+                items.sort()
 
                 return self.finish(json.dumps(dict(workspaces=items)))
             except Exception as e:

--- a/jupyterlab_launcher/workspaces_handler.py
+++ b/jupyterlab_launcher/workspaces_handler.py
@@ -19,9 +19,12 @@ class WorkspacesHandler(APIHandler):
 
     @json_errors
     @web.authenticated
-    def get(self, space_name):
+    def get(self, space_name=''):
         directory = self.workspaces_dir
         self.set_header('Content-Type', 'application/json')
+        if not space_name:
+            raise web.HTTPError(404, 'Workspaces list not yet implemented')
+
         workspace_path = os.path.join(directory, space_name + _file_extension)
         if os.path.exists(workspace_path):
             with open(workspace_path) as fid:


### PR DESCRIPTION
- [x] Support workspace listing
- [x] Add workspace listing test
- [x] Support workspace deletion
- [x] Add workspace deletion test

These changes are backward-compatible, so we can publish them as version `0.11.1`