### PR TITLE
jupyterlab_launcher is dependent on subprocess32 >=v3.3

### DIFF
--- a/jupyterlab_launcher/process.py
+++ b/jupyterlab_launcher/process.py
@@ -109,6 +109,9 @@ class Process(object):
             # subprocess.DEVNULL was only implemented in version 3.3
             if hasattr(subprocess, 'DEVNULL'):
                 kwargs['stdout'] = subprocess.DEVNULL
+            else:
+                msg = 'Please install subprocess32 v3.3 or higher.'
+                raise ValueError(msg)
 
         self.proc = self._create_process(cwd=cwd, env=env, **kwargs)
         self._kill_event = kill_event or threading.Event()

--- a/jupyterlab_launcher/process.py
+++ b/jupyterlab_launcher/process.py
@@ -106,7 +106,9 @@ class Process(object):
 
         kwargs = {}
         if quiet:
-            kwargs['stdout'] = subprocess.DEVNULL
+            # subprocess.DEVNULL was only implemented in version 3.3
+            if hasattr(subprocess, 'DEVNULL'):
+                kwargs['stdout'] = subprocess.DEVNULL
 
         self.proc = self._create_process(cwd=cwd, env=env, **kwargs)
         self._kill_event = kill_event or threading.Event()


### PR DESCRIPTION
subprocess32.DEVNULL is used by 
`jupyterlab_launcher.process.Process(quiet=True)`. 

The attribute DEVNULL has only been added in version 3.3 (https://docs.python.org/3/library/subprocess.html). 

jupyterlab.commands._node_check sets quiet=True. With an old version of subprocess32, this gives an error which is interpreted by the try-except in _node_check as nodejs < v4.5 which makes troubleshooting for the user difficult (see https://github.com/jupyterlab/jupyterlab/pull/5083).

The second commit will raise a ValueError with a description of the problem. This is only helpful if https://github.com/jupyterlab/jupyterlab/pull/5083 is accepted because it wouldn't reach the user otherwise due to the try-except.

With the first commit alone, DEVNULL is only used if available so it would solve the problem but it would be unclear why jupyterlab_launcher.process.Process is not quiet.

