### PR TITLE
Fix PY2 handing of potential non-unicode paths being slugified.

### DIFF
--- a/jupyterlab_launcher/workspaces_handler.py
+++ b/jupyterlab_launcher/workspaces_handler.py
@@ -72,7 +72,8 @@ def _slug(raw, base, sign=True, max_length=128 - len(_file_extension)):
     while common < limit and base[common] == raw[common]:
         common += 1
     value = ujoin(base[common:], raw)
-    value = urllib.unquote(value) if PY2 else urllib.parse.unquote(value)
+    value = (unicode(urllib.unquote(value))
+             if PY2 else urllib.parse.unquote(value))
     value = (unicodedata
              .normalize('NFKC', value)
              .encode('ascii', 'ignore')


### PR DESCRIPTION
cf. this broken services test build output: https://travis-ci.org/jupyterlab/jupyterlab/jobs/414480761

<img width="1066" alt="services test build output" src="https://user-images.githubusercontent.com/159529/43964906-c9ee0876-9cb5-11e8-9fd4-e3341ff09f65.png">
